### PR TITLE
Move all .cfg files to etc/mock directory for

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ release-free :
 		> mock-rpmfusion-free.spec
 	cat CHANGELOG >> mock-rpmfusion-free.spec
 	tar cjvf mock-rpmfusion-free-$(VERSION).tar.bz2 \
-		fedora-*_free.cfg \
-		epel-*_free.cfg \
+		etc/mock/fedora-*_free.cfg \
+		etc/mock/epel-*_free.cfg \
 		mock-rpmfusion-free.spec
 
 release-nonfree : 
@@ -18,8 +18,8 @@ release-nonfree :
 		> mock-rpmfusion-nonfree.spec
 	cat CHANGELOG >> mock-rpmfusion-nonfree.spec
 	tar cjvf mock-rpmfusion-nonfree-$(VERSION).tar.bz2 \
-		fedora-*_nonfree.cfg \
-		epel-*_nonfree.cfg \
+		etc/mock/fedora-*_nonfree.cfg \
+		etc/mock/epel-*_nonfree.cfg \
 		mock-rpmfusion-nonfree.spec
 
 release-kwizart :
@@ -28,8 +28,8 @@ release-kwizart :
 		> mock-kwizart.spec
 	cat CHANGELOG >> mock-kwizart.spec
 	tar cjvf mock-kwizart-$(VERSION).tar.bz2 \
-		fedora-*kwizart.cfg \
-		epel-*kwizart.cfg \
+		etc/mock/fedora-*kwizart.cfg \
+		etc/mock/epel-*kwizart.cfg \
 		mock-kwizart*.spec
 
 clean :	

--- a/el-round.sh
+++ b/el-round.sh
@@ -40,6 +40,7 @@ for arch in $ARCHES ; do
   #sed -i -e "s|#baseurl=http://download1.rpmfusion.org/nonfree/fedora/|baseurl=http://download1.rpmfusion.org/nonfree/fedora-secondary/|g" fedora-${fver}-${arch2}-${repo}.cfg
 #done
 
+  mv epel-${fver}-${arch}-${repo}.cfg etc/mock
 ### /script
     done
   done

--- a/mock-kwizart.spec.in
+++ b/mock-kwizart.spec.in
@@ -27,7 +27,7 @@ Mock config files for the rpms.kwizart.net Repository
 %install
 rm -rf $RPM_BUILD_ROOT
 mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/mock
-install -pm 0644 *kwizart.cfg $RPM_BUILD_ROOT%{_sysconfdir}/mock
+install -pm 0644 etc/mock/*kwizart.cfg $RPM_BUILD_ROOT%{_sysconfdir}/mock
 
 
 %clean

--- a/mock-rpmfusion-free.spec.in
+++ b/mock-rpmfusion-free.spec.in
@@ -27,7 +27,7 @@ Mock config files for the RPM Fusion Free Repository
 %install
 rm -rf $RPM_BUILD_ROOT
 mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/mock
-install -pm 0644 *.cfg $RPM_BUILD_ROOT%{_sysconfdir}/mock
+install -pm 0644 etc/mock/*.cfg $RPM_BUILD_ROOT%{_sysconfdir}/mock
 
 
 %clean

--- a/mock-rpmfusion-nonfree.spec.in
+++ b/mock-rpmfusion-nonfree.spec.in
@@ -27,7 +27,7 @@ Mock config files for the RPM Fusion NonFree Repository
 %install
 rm -rf $RPM_BUILD_ROOT
 mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/mock
-install -pm 0644 *.cfg $RPM_BUILD_ROOT%{_sysconfdir}/mock
+install -pm 0644 etc/mock/*.cfg $RPM_BUILD_ROOT%{_sysconfdir}/mock
 
 
 %clean

--- a/round.sh
+++ b/round.sh
@@ -44,10 +44,13 @@ for arch in $ARCHES ; do
   sed -i -e "s|\$releasever|${fver}|g" fedora-${fver}-${arch}-${repo}.cfg
   if [  ! $arch == i386 -a ! $arch == x86_64 ] ; then
     if [ "$arch" == "armhfp" -a "${ffver}" -gt "19" ] ; then
-      continue
+        :
+    else
+        #echo sed it fedora-${fver}-${arch}-${repo}.cfg
+        sed -i -e "s|free/fedora/|free/fedora-secondary/|g" fedora-${fver}-${arch}-${repo}.cfg
     fi
-    sed -i -e "s|free/fedora/|free/fedora-secondary/|g" fedora-${fver}-${arch}-${repo}.cfg
   fi
+  mv fedora-${fver}-${arch}-${repo}.cfg etc/mock
   #sed -i -e "s|mirrorlist=http://mirrors.rpmfusion.org|#mirrorlist=http://mirrors.rpmfusion.org|g" fedora-${fver}-${arch2}-${repo}.cfg
   #sed -i -e "s|kojipkgs.fedoraproject.org|sparc.koji.fedoraproject.org|g" fedora-${fver}-${arch2}-${repo}.cfg
   #sed -i -e "s|#baseurl=http://download1.rpmfusion.org/nonfree/fedora/|baseurl=http://download1.rpmfusion.org/nonfree/fedora-secondary/|g" fedora-${fver}-${arch2}-${repo}.cfg


### PR DESCRIPTION
It is organization ! 
I need it to find templates and control what changes, these files are generated so all generated files should go to a directory (etc/mock), and not stay on base directory. Is a question of organize things. I'd like move more than 100 files to one directory.