### PR TITLE
Print and remove obsoleted .cfg files.

### DIFF
--- a/el-round.sh
+++ b/el-round.sh
@@ -18,7 +18,10 @@ for arch in $ARCHES ; do
 
   flavour=epel
   ffver=$fver
-  if [ ! -f /etc/mock/epel-${fver}-${arch}.cfg ] ; then
+  if [ ! -f ${etc_mock}/epel-${fver}-${arch}.cfg ] ; then
+    echo "doesnt exit ${etc_mock}/epel-${fver}-${arch}.cfg"
+    # removing obsoleted .cfg
+    rm -f epel-${fver}-${arch}-${repo}.cfg
     continue
   fi
   cp template_init epel-${fver}-${arch}-${repo}.cfg

--- a/round.sh
+++ b/round.sh
@@ -27,6 +27,8 @@ for arch in $ARCHES ; do
   fi
   if [ ! -f ${etc_mock}/fedora-${fver}-${arch}.cfg ] ; then
     echo "doesnt exit ${etc_mock}/fedora-${fver}-${arch}.cfg"
+    # removing obsoleted .cfg
+    rm -f fedora-${fver}-${arch}-${repo}.cfg
     continue
   fi
   cp template_init fedora-${fver}-${arch}-${repo}.cfg


### PR DESCRIPTION
good to debug problems and not ship obsoleted files.
also fix one bug use ${etc_mock} instead /etc/mock/ 