### PR TITLE
Insert root into generated config

### DIFF
--- a/el-round.sh
+++ b/el-round.sh
@@ -17,13 +17,13 @@ for arch in $ARCHES ; do
   flavour=epel
   ffver=$fver
   if [ ! -f ${etc_mock}/epel-${fver}-${arch}.cfg ] ; then
-    echo "doesnt exit ${etc_mock}/epel-${fver}-${arch}.cfg"
+    echo "doesnt exist ${etc_mock}/epel-${fver}-${arch}.cfg"
     # removing obsoleted .cfg
     rm -f epel-${fver}-${arch}-${repo}.cfg
     continue
   fi
   cp template_init epel-${fver}-${arch}-${repo}.cfg
-  sed -i -e "s|configuration_name|epel-${fver}-${arch}.cfg|g" epel-${fver}-${arch}-${repo}.cfg
+  sed -i -e "s|root_line|config_opts['root'] = 'epel-${fver}-${arch}'|g;s|configuration_name|epel-${fver}-${arch}.cfg|g" epel-${fver}-${arch}-${repo}.cfg
   cat rpmfusion_free-$flavour-template >> epel-${fver}-${arch}-${repo}.cfg
   if [ ! "$repo" = rpmfusion_free ] ; then
     cat rpmfusion_nonfree-$flavour-template >> epel-${fver}-${arch}-${repo}.cfg

--- a/round.sh
+++ b/round.sh
@@ -36,6 +36,7 @@ for arch in $ARCHES ; do
   fi
   cp template_init fedora-${fver}-${arch}-${repo}.cfg
   cat ${repo}-${flavour}-template >> fedora-${fver}-${arch}-${repo}.cfg
+  sed -i -e "s|root_line|config_opts['root'] = 'fedora-${fver}-${arch}'|g" fedora-${fver}-${arch}-${repo}.cfg
   if [ "$repo" = rpmfusion_free ] ; then
     sed -i -e "s|configuration_name|fedora-${fver}-${arch}.cfg|g" fedora-${fver}-${arch}-${repo}.cfg
   fi

--- a/round.sh
+++ b/round.sh
@@ -29,7 +29,7 @@ for arch in $ARCHES ; do
     fver=rawhide
   fi
   if [ ! -f ${etc_mock}/fedora-${fver}-${arch}.cfg ] ; then
-    echo "doesnt exit ${etc_mock}/fedora-${fver}-${arch}.cfg"
+    echo "doesnt exist ${etc_mock}/fedora-${fver}-${arch}.cfg"
     # removing obsoleted .cfg
     rm -f fedora-${fver}-${arch}-${repo}.cfg
     continue

--- a/template_init
+++ b/template_init
@@ -1,3 +1,4 @@
 include('/etc/mock/configuration_name')
+root_line
 
 config_opts['yum.conf'] += """


### PR DESCRIPTION
This addresses the issue Martin brought up recently on the mailing list, where `fedora-review` throws a traceback whenever using an rpmfusion mock definition.

`fedora-review`'s mock parser doesn't understand `include()` instructions yet. (Sérgio submitted a patch, but it was never released.) It wants to parse the root definition out of the config, so add one to keep it happy.

Worked for me with `fedora-29-x86_64-rpmfusion_free.cfg` and `

I was going to link to the mailing list discussion above, but the rpmfusion-developer list archive doesn't show the text of Martin's email, and none of the replies are visible **at all**. (That actually seems to be true for all threads, not just this one.)

So, not super useful, but here's the link: [[rpmfusion-developers] fedora-review always ends with ERROR](https://lists.rpmfusion.org/archives/list/rpmfusion-developers@lists.rpmfusion.org/thread/Q2FOITU7EKB3MTZSYY55SNWHHCN52ZLZ/)