### PR TITLE
Allow --enablerepo=rpmfusion-{non,}free-override to work out of the box

### DIFF
--- a/mock-rpmfusion-free.spec.in
+++ b/mock-rpmfusion-free.spec.in
@@ -6,6 +6,7 @@ Summary:        Mock config files for the RPM Fusion Free Repository
 License:        BSD
 URL:            https://rpmfusion.org/
 Source0:        https://github.com/rpmfusion-infra/mock-rpmfusion/releases/download/%{version}/%{name}-%{version}.tar.bz2
+Source1:        https://admin.rpmfusion.org/accounts/rpmfusion-server-ca.cert
 
 BuildArch:      noarch
 Requires:       mock-core-configs >= 30
@@ -25,10 +26,12 @@ Mock config files for the RPM Fusion Free Repository
 %install
 mkdir -p %{buildroot}%{_sysconfdir}/mock
 install -pm 0644 etc/mock/*_free.cfg %{buildroot}%{_sysconfdir}/mock
+install -pm 0644 %{SOURCE1} %{buildroot}%{_sysconfdir}/mock/rpmfusion-server-ca.cert
 
 
 %files
 %config(noreplace) %{_sysconfdir}/mock/*_free.cfg
+%config(noreplace) %{_sysconfdir}/mock/rpmfusion-server-ca.cert
 
 
 %changelog

--- a/mock-rpmfusion-free.spec.in
+++ b/mock-rpmfusion-free.spec.in
@@ -3,7 +3,6 @@ Version:        @VERSION@
 Release:        1%{?dist}
 Summary:        Mock config files for the RPM Fusion Free Repository
 
-Group:          Development/Tools
 License:        BSD
 URL:            https://rpmfusion.org/
 Source0:        https://github.com/rpmfusion-infra/mock-rpmfusion/releases/download/%{version}/%{name}-%{version}.tar.bz2
@@ -29,7 +28,6 @@ install -pm 0644 etc/mock/*_free.cfg %{buildroot}%{_sysconfdir}/mock
 
 
 %files
-%defattr(-,root,root,-)
 %config(noreplace) %{_sysconfdir}/mock/*_free.cfg
 
 

--- a/mock-rpmfusion-nonfree.spec.in
+++ b/mock-rpmfusion-nonfree.spec.in
@@ -3,7 +3,6 @@ Version:        @VERSION@
 Release:        1%{?dist}
 Summary:        Mock config files for the RPM Fusion NonFree Repository
 
-Group:          Development/Tools
 License:        BSD
 URL:            https://rpmfusion.org/
 Source0:        https://github.com/rpmfusion-infra/mock-rpmfusion/releases/download/%{version}/%{name}-%{version}.tar.bz2
@@ -29,7 +28,6 @@ install -pm 0644 etc/mock/*_nonfree.cfg %{buildroot}%{_sysconfdir}/mock
 
 
 %files
-%defattr(-,root,root,-)
 %config(noreplace) %{_sysconfdir}/mock/*_nonfree.cfg
 
 

--- a/rpmfusion_free-branched-template
+++ b/rpmfusion_free-branched-template
@@ -47,6 +47,7 @@ enabled=0
 [local-free]
 name=RPM Fusion for Fedora $releasever - Free - Local repo
 baseurl=https://koji.rpmfusion.org/kojifiles/repos/f$releasever-free-build/latest/$basearch/
+sslcacert=/etc/mock/rpmfusion-server-ca.cert
 cost=2000
 enabled=0
 
@@ -54,6 +55,7 @@ enabled=0
 #[buildsys-override-free]
 #name=RPM Fusion for Fedora $releasever - Free - Buildsys override
 #baseurl=https://koji.rpmfusion.org/buildsys-override/f$releasever-free/$basearch/
+#sslcacert=/etc/mock/rpmfusion-server-ca.cert
 #cost=2000
 #enabled=0
 

--- a/rpmfusion_free-epel-template
+++ b/rpmfusion_free-epel-template
@@ -13,12 +13,14 @@ enabled=1
 [local-free]
 name=RPM Fusion for EL $releasever - Free - Local repo
 baseurl=https://koji.rpmfusion.org/kojifiles/repos/el$releasever-free-build/latest/$basearch/
+sslcacert=/etc/mock/rpmfusion-server-ca.cert
 cost=2000
 enabled=0
 
 [buildsys-override-free]
 name=RPM Fusion for EL $releasever - Free - Buildsys override
 baseurl=https://koji.rpmfusion.org/buildsys-override/el$releasever-free/$basearch/
+sslcacert=/etc/mock/rpmfusion-server-ca.cert
 cost=2000
 enabled=0
 

--- a/rpmfusion_free-rawhide-template
+++ b/rpmfusion_free-rawhide-template
@@ -8,6 +8,7 @@ enabled=1
 [local-free]
 name=RPM Fusion for Fedora Rawhide - Free - Local repo
 baseurl=https://koji.rpmfusion.org/kojifiles/repos/f$releasever-free-build/latest/$basearch/
+sslcacert=/etc/mock/rpmfusion-server-ca.cert
 cost=2000
 enabled=0
 

--- a/rpmfusion_free-rawhide-template
+++ b/rpmfusion_free-rawhide-template
@@ -7,7 +7,7 @@ enabled=1
 
 [local-free]
 name=RPM Fusion for Fedora Rawhide - Free - Local repo
-baseurl=http://koji.rpmfusion.org/kojifiles/repos/f$releasever-free-build/latest/$basearch/
+baseurl=https://koji.rpmfusion.org/kojifiles/repos/f$releasever-free-build/latest/$basearch/
 cost=2000
 enabled=0
 

--- a/rpmfusion_free-stable-template
+++ b/rpmfusion_free-stable-template
@@ -41,12 +41,14 @@ enabled=0
 [local-free]
 name=RPM Fusion for Fedora $releasever - Free - Local repo
 baseurl=https://koji.rpmfusion.org/kojifiles/repos/f$releasever-free-build/latest/$basearch/
+sslcacert=/etc/mock/rpmfusion-server-ca.cert
 cost=2000
 enabled=0
 
 [buildsys-override-free]
 name=RPM Fusion for Fedora $releasever - Free - Buildsys override
 baseurl=https://koji.rpmfusion.org/buildsys-override/f$releasever-free/$basearch/
+sslcacert=/etc/mock/rpmfusion-server-ca.cert
 cost=2000
 enabled=0
 

--- a/rpmfusion_nonfree-branched-template
+++ b/rpmfusion_nonfree-branched-template
@@ -47,6 +47,7 @@ enabled=0
 [local-nonfree]
 name=RPM Fusion for Fedora $releasever - Nonfree - Local repo
 baseurl=https://koji.rpmfusion.org/kojifiles/repos/f$releasever-nonfree-build/latest/$basearch/
+sslcacert=/etc/mock/rpmfusion-server-ca.cert
 cost=2000
 enabled=0
 
@@ -54,6 +55,7 @@ enabled=0
 #[buildsys-override-nonfree]
 #name=RPM Fusion for Fedora $releasever - Nonfree - Buildsys override
 #baseurl=https://koji.rpmfusion.org/buildsys-override/f$releasever-nonfree/$basearch/
+#sslcacert=/etc/mock/rpmfusion-server-ca.cert
 #cost=2000
 #enabled=0
 

--- a/rpmfusion_nonfree-branched-template
+++ b/rpmfusion_nonfree-branched-template
@@ -50,7 +50,7 @@ baseurl=https://koji.rpmfusion.org/kojifiles/repos/f$releasever-nonfree-build/la
 cost=2000
 enabled=0
 
-#mirrorlist=http://mirrors.rpmfusion.org/mirrorlist?repo=nonfree-fedora-updates-released-$releasever&arch=$basearch
+#mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=nonfree-fedora-updates-released-$releasever&arch=$basearch
 #[buildsys-override-nonfree]
 #name=RPM Fusion for Fedora $releasever - Nonfree - Buildsys override
 #baseurl=https://koji.rpmfusion.org/buildsys-override/f$releasever-nonfree/$basearch/

--- a/rpmfusion_nonfree-epel-template
+++ b/rpmfusion_nonfree-epel-template
@@ -13,12 +13,14 @@ enabled=1
 [local-nonfree]
 name=RPM Fusion for EL $releasever - NonFree - Local repo
 baseurl=https://koji.rpmfusion.org/kojifiles/repos/el$releasever-nonfree/latest/$basearch/
+sslcacert=/etc/mock/rpmfusion-server-ca.cert
 cost=2000
 enabled=0
 
 [buildsys-override-nonfree]
 name=RPM Fusion for EL $releasever - NonFree - Buildsys override
 baseurl=https://koji.rpmfusion.org/buildsys-override/el$releasever-nonfree/$basearch/
+sslcacert=/etc/mock/rpmfusion-server-ca.cert
 cost=2000
 enabled=0
 

--- a/rpmfusion_nonfree-rawhide-template
+++ b/rpmfusion_nonfree-rawhide-template
@@ -8,6 +8,7 @@ enabled=1
 [local-nonfree]
 name=RPM Fusion for Fedora Rawhide - Nonfree - Local repo
 baseurl=https://koji.rpmfusion.org/kojifiles/repos/f$releasever-nonfree-build/latest/$basearch/
+sslcacert=/etc/mock/rpmfusion-server-ca.cert
 cost=2000
 enabled=0
 

--- a/rpmfusion_nonfree-rawhide-template
+++ b/rpmfusion_nonfree-rawhide-template
@@ -7,7 +7,7 @@ enabled=1
 
 [local-nonfree]
 name=RPM Fusion for Fedora Rawhide - Nonfree - Local repo
-baseurl=http://koji.rpmfusion.org/kojifiles/repos/f$releasever-nonfree-build/latest/$basearch/
+baseurl=https://koji.rpmfusion.org/kojifiles/repos/f$releasever-nonfree-build/latest/$basearch/
 cost=2000
 enabled=0
 

--- a/rpmfusion_nonfree-stable-template
+++ b/rpmfusion_nonfree-stable-template
@@ -41,12 +41,14 @@ enabled=0
 [local-nonfree]
 name=RPM Fusion for Fedora $releasever - Nonfree - Local repo
 baseurl=https://koji.rpmfusion.org/kojifiles/repos/f$releasever-nonfree-build/latest/$basearch/
+sslcacert=/etc/mock/rpmfusion-server-ca.cert
 cost=2000
 enabled=0
 
 [buildsys-override-nonfree]
 name=RPM Fusion for Fedora $releasever - Nonfree - Buildsys override
 baseurl=https://koji.rpmfusion.org/buildsys-override/f$releasever-nonfree/$basearch/
+sslcacert=/etc/mock/rpmfusion-server-ca.cert
 cost=2000
 enabled=0
 


### PR DESCRIPTION
Passing --enablerepo=rpmfusion-{non,}free-override to mock or rfpkg is not working out of the box because the repositories definitions pointing at koji.rpmfusion are using https and the CA needed to verify it is not available to mock.

This PR adds the CA to mock-rpmfusion-free package and fixes the relevant repositories definition to use the CA to validate koji.rpmfusion.org.

The issue and the solution implemented is described in more length here :
https://lists.rpmfusion.org/archives/list/rpmfusion-developers@lists.rpmfusion.org/message/LNURKVKM77GFKDFV5N3GKQMLRGLUJSQH/

Also, a couple drive-by cleanups.