### PR TITLE
replace yum.conf with dnf.conf on Fedora and EPEL-8

### DIFF
--- a/etc/mock/epel-8-aarch64-kwizart.cfg
+++ b/etc/mock/epel-8-aarch64-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/epel-8-aarch64.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free-updates]
 name=RPM Fusion for EL 8 - Free - Updates
 #baseurl=https://download1.rpmfusion.org/free/el/updates/8/aarch64/

--- a/etc/mock/epel-8-aarch64-rpmfusion_free.cfg
+++ b/etc/mock/epel-8-aarch64-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/epel-8-aarch64.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free-updates]
 name=RPM Fusion for EL 8 - Free - Updates
 #baseurl=https://download1.rpmfusion.org/free/el/updates/8/aarch64/

--- a/etc/mock/epel-8-aarch64-rpmfusion_nonfree.cfg
+++ b/etc/mock/epel-8-aarch64-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/epel-8-aarch64.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free-updates]
 name=RPM Fusion for EL 8 - Free - Updates
 #baseurl=https://download1.rpmfusion.org/free/el/updates/8/aarch64/

--- a/etc/mock/epel-8-ppc64le-kwizart.cfg
+++ b/etc/mock/epel-8-ppc64le-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/epel-8-ppc64le.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free-updates]
 name=RPM Fusion for EL 8 - Free - Updates
 #baseurl=https://download1.rpmfusion.org/free/el/updates/8/ppc64le/

--- a/etc/mock/epel-8-ppc64le-rpmfusion_free.cfg
+++ b/etc/mock/epel-8-ppc64le-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/epel-8-ppc64le.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free-updates]
 name=RPM Fusion for EL 8 - Free - Updates
 #baseurl=https://download1.rpmfusion.org/free/el/updates/8/ppc64le/

--- a/etc/mock/epel-8-ppc64le-rpmfusion_nonfree.cfg
+++ b/etc/mock/epel-8-ppc64le-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/epel-8-ppc64le.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free-updates]
 name=RPM Fusion for EL 8 - Free - Updates
 #baseurl=https://download1.rpmfusion.org/free/el/updates/8/ppc64le/

--- a/etc/mock/epel-8-x86_64-kwizart.cfg
+++ b/etc/mock/epel-8-x86_64-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/epel-8-x86_64.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free-updates]
 name=RPM Fusion for EL 8 - Free - Updates
 #baseurl=https://download1.rpmfusion.org/free/el/updates/8/x86_64/

--- a/etc/mock/epel-8-x86_64-rpmfusion_free.cfg
+++ b/etc/mock/epel-8-x86_64-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/epel-8-x86_64.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free-updates]
 name=RPM Fusion for EL 8 - Free - Updates
 #baseurl=https://download1.rpmfusion.org/free/el/updates/8/x86_64/

--- a/etc/mock/epel-8-x86_64-rpmfusion_nonfree.cfg
+++ b/etc/mock/epel-8-x86_64-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/epel-8-x86_64.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free-updates]
 name=RPM Fusion for EL 8 - Free - Updates
 #baseurl=https://download1.rpmfusion.org/free/el/updates/8/x86_64/

--- a/etc/mock/fedora-30-aarch64-kwizart.cfg
+++ b/etc/mock/fedora-30-aarch64-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-30-aarch64-rpmfusion_nonfree.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [kwizart]
 name=kwizart for Fedora 30 - aarch64 - Base
 baseurl=http://rpms.kwizart.net/fedora/30/aarch64/

--- a/etc/mock/fedora-30-aarch64-rpmfusion_free.cfg
+++ b/etc/mock/fedora-30-aarch64-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-30-aarch64.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free]
 name=RPM Fusion for Fedora 30 - Free
 #baseurl=https://download1.rpmfusion.org/free/fedora/releases/30/Everything/aarch64/os/

--- a/etc/mock/fedora-30-aarch64-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-30-aarch64-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-30-aarch64-rpmfusion_free.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-nonfree]
 name=RPM Fusion for Fedora 30 - Nonfree
 #baseurl=https://download1.rpmfusion.org/nonfree/fedora/releases/30/Everything/aarch64/os/

--- a/etc/mock/fedora-30-armhfp-kwizart.cfg
+++ b/etc/mock/fedora-30-armhfp-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-30-armhfp-rpmfusion_nonfree.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [kwizart]
 name=kwizart for Fedora 30 - armhfp - Base
 baseurl=http://rpms.kwizart.net/fedora/30/armhfp/

--- a/etc/mock/fedora-30-armhfp-rpmfusion_free.cfg
+++ b/etc/mock/fedora-30-armhfp-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-30-armhfp.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free]
 name=RPM Fusion for Fedora 30 - Free
 #baseurl=https://download1.rpmfusion.org/free/fedora/releases/30/Everything/armhfp/os/

--- a/etc/mock/fedora-30-armhfp-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-30-armhfp-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-30-armhfp-rpmfusion_free.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-nonfree]
 name=RPM Fusion for Fedora 30 - Nonfree
 #baseurl=https://download1.rpmfusion.org/nonfree/fedora/releases/30/Everything/armhfp/os/

--- a/etc/mock/fedora-30-i386-kwizart.cfg
+++ b/etc/mock/fedora-30-i386-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-30-i386-rpmfusion_nonfree.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [kwizart]
 name=kwizart for Fedora 30 - i386 - Base
 baseurl=http://rpms.kwizart.net/fedora/30/i386/

--- a/etc/mock/fedora-30-i386-rpmfusion_free.cfg
+++ b/etc/mock/fedora-30-i386-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-30-i386.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free]
 name=RPM Fusion for Fedora 30 - Free
 #baseurl=https://download1.rpmfusion.org/free/fedora/releases/30/Everything/i386/os/

--- a/etc/mock/fedora-30-i386-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-30-i386-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-30-i386-rpmfusion_free.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-nonfree]
 name=RPM Fusion for Fedora 30 - Nonfree
 #baseurl=https://download1.rpmfusion.org/nonfree/fedora/releases/30/Everything/i386/os/

--- a/etc/mock/fedora-30-ppc64le-kwizart.cfg
+++ b/etc/mock/fedora-30-ppc64le-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-30-ppc64le-rpmfusion_nonfree.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [kwizart]
 name=kwizart for Fedora 30 - ppc64le - Base
 baseurl=http://rpms.kwizart.net/fedora/30/ppc64le/

--- a/etc/mock/fedora-30-ppc64le-rpmfusion_free.cfg
+++ b/etc/mock/fedora-30-ppc64le-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-30-ppc64le.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free]
 name=RPM Fusion for Fedora 30 - Free
 #baseurl=https://download1.rpmfusion.org/free/fedora/releases/30/Everything/ppc64le/os/

--- a/etc/mock/fedora-30-ppc64le-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-30-ppc64le-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-30-ppc64le-rpmfusion_free.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-nonfree]
 name=RPM Fusion for Fedora 30 - Nonfree
 #baseurl=https://download1.rpmfusion.org/nonfree/fedora/releases/30/Everything/ppc64le/os/

--- a/etc/mock/fedora-30-x86_64-kwizart.cfg
+++ b/etc/mock/fedora-30-x86_64-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-30-x86_64-rpmfusion_nonfree.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [kwizart]
 name=kwizart for Fedora 30 - x86_64 - Base
 baseurl=http://rpms.kwizart.net/fedora/30/x86_64/

--- a/etc/mock/fedora-30-x86_64-rpmfusion_free.cfg
+++ b/etc/mock/fedora-30-x86_64-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-30-x86_64.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free]
 name=RPM Fusion for Fedora 30 - Free
 #baseurl=https://download1.rpmfusion.org/free/fedora/releases/30/Everything/x86_64/os/

--- a/etc/mock/fedora-30-x86_64-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-30-x86_64-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-30-x86_64-rpmfusion_free.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-nonfree]
 name=RPM Fusion for Fedora 30 - Nonfree
 #baseurl=https://download1.rpmfusion.org/nonfree/fedora/releases/30/Everything/x86_64/os/

--- a/etc/mock/fedora-31-aarch64-kwizart.cfg
+++ b/etc/mock/fedora-31-aarch64-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-31-aarch64-rpmfusion_nonfree.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [kwizart]
 name=kwizart for Fedora 31 - aarch64 - Base
 baseurl=http://rpms.kwizart.net/fedora/31/aarch64/

--- a/etc/mock/fedora-31-aarch64-rpmfusion_free.cfg
+++ b/etc/mock/fedora-31-aarch64-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-31-aarch64.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free]
 name=RPM Fusion for Fedora 31 - Free
 #baseurl=https://download1.rpmfusion.org/free/fedora/releases/31/Everything/aarch64/os/

--- a/etc/mock/fedora-31-aarch64-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-31-aarch64-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-31-aarch64-rpmfusion_free.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-nonfree]
 name=RPM Fusion for Fedora 31 - Nonfree
 #baseurl=https://download1.rpmfusion.org/nonfree/fedora/releases/31/Everything/aarch64/os/

--- a/etc/mock/fedora-31-armhfp-kwizart.cfg
+++ b/etc/mock/fedora-31-armhfp-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-31-armhfp-rpmfusion_nonfree.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [kwizart]
 name=kwizart for Fedora 31 - armhfp - Base
 baseurl=http://rpms.kwizart.net/fedora/31/armhfp/

--- a/etc/mock/fedora-31-armhfp-rpmfusion_free.cfg
+++ b/etc/mock/fedora-31-armhfp-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-31-armhfp.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free]
 name=RPM Fusion for Fedora 31 - Free
 #baseurl=https://download1.rpmfusion.org/free/fedora/releases/31/Everything/armhfp/os/

--- a/etc/mock/fedora-31-armhfp-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-31-armhfp-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-31-armhfp-rpmfusion_free.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-nonfree]
 name=RPM Fusion for Fedora 31 - Nonfree
 #baseurl=https://download1.rpmfusion.org/nonfree/fedora/releases/31/Everything/armhfp/os/

--- a/etc/mock/fedora-31-i386-kwizart.cfg
+++ b/etc/mock/fedora-31-i386-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-31-i386-rpmfusion_nonfree.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [kwizart]
 name=kwizart for Fedora 31 - i386 - Base
 baseurl=http://rpms.kwizart.net/fedora/31/i386/

--- a/etc/mock/fedora-31-i386-rpmfusion_free.cfg
+++ b/etc/mock/fedora-31-i386-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-31-i386.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free]
 name=RPM Fusion for Fedora 31 - Free
 #baseurl=https://download1.rpmfusion.org/free/fedora/releases/31/Everything/i386/os/

--- a/etc/mock/fedora-31-i386-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-31-i386-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-31-i386-rpmfusion_free.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-nonfree]
 name=RPM Fusion for Fedora 31 - Nonfree
 #baseurl=https://download1.rpmfusion.org/nonfree/fedora/releases/31/Everything/i386/os/

--- a/etc/mock/fedora-31-ppc64le-kwizart.cfg
+++ b/etc/mock/fedora-31-ppc64le-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-31-ppc64le-rpmfusion_nonfree.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [kwizart]
 name=kwizart for Fedora 31 - ppc64le - Base
 baseurl=http://rpms.kwizart.net/fedora/31/ppc64le/

--- a/etc/mock/fedora-31-ppc64le-rpmfusion_free.cfg
+++ b/etc/mock/fedora-31-ppc64le-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-31-ppc64le.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free]
 name=RPM Fusion for Fedora 31 - Free
 #baseurl=https://download1.rpmfusion.org/free/fedora/releases/31/Everything/ppc64le/os/

--- a/etc/mock/fedora-31-ppc64le-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-31-ppc64le-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-31-ppc64le-rpmfusion_free.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-nonfree]
 name=RPM Fusion for Fedora 31 - Nonfree
 #baseurl=https://download1.rpmfusion.org/nonfree/fedora/releases/31/Everything/ppc64le/os/

--- a/etc/mock/fedora-31-x86_64-kwizart.cfg
+++ b/etc/mock/fedora-31-x86_64-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-31-x86_64-rpmfusion_nonfree.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [kwizart]
 name=kwizart for Fedora 31 - x86_64 - Base
 baseurl=http://rpms.kwizart.net/fedora/31/x86_64/

--- a/etc/mock/fedora-31-x86_64-rpmfusion_free.cfg
+++ b/etc/mock/fedora-31-x86_64-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-31-x86_64.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free]
 name=RPM Fusion for Fedora 31 - Free
 #baseurl=https://download1.rpmfusion.org/free/fedora/releases/31/Everything/x86_64/os/

--- a/etc/mock/fedora-31-x86_64-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-31-x86_64-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-31-x86_64-rpmfusion_free.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-nonfree]
 name=RPM Fusion for Fedora 31 - Nonfree
 #baseurl=https://download1.rpmfusion.org/nonfree/fedora/releases/31/Everything/x86_64/os/

--- a/etc/mock/fedora-32-aarch64-kwizart.cfg
+++ b/etc/mock/fedora-32-aarch64-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-32-aarch64-rpmfusion_nonfree.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [kwizart]
 name=kwizart for Fedora 32 - aarch64 - Base
 baseurl=http://rpms.kwizart.net/fedora/32/aarch64/

--- a/etc/mock/fedora-32-aarch64-rpmfusion_free.cfg
+++ b/etc/mock/fedora-32-aarch64-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-32-aarch64.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free]
 name=RPM Fusion for Fedora 32 - Free
 #baseurl=https://download1.rpmfusion.org/free/fedora/releases/32/Everything/aarch64/os/

--- a/etc/mock/fedora-32-aarch64-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-32-aarch64-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-32-aarch64-rpmfusion_free.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-nonfree]
 name=RPM Fusion for Fedora 32 - Nonfree
 #baseurl=https://download1.rpmfusion.org/nonfree/fedora/releases/32/Everything/aarch64/os/

--- a/etc/mock/fedora-32-armhfp-kwizart.cfg
+++ b/etc/mock/fedora-32-armhfp-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-32-armhfp-rpmfusion_nonfree.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [kwizart]
 name=kwizart for Fedora 32 - armhfp - Base
 baseurl=http://rpms.kwizart.net/fedora/32/armhfp/

--- a/etc/mock/fedora-32-armhfp-rpmfusion_free.cfg
+++ b/etc/mock/fedora-32-armhfp-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-32-armhfp.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free]
 name=RPM Fusion for Fedora 32 - Free
 #baseurl=https://download1.rpmfusion.org/free/fedora/releases/32/Everything/armhfp/os/

--- a/etc/mock/fedora-32-armhfp-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-32-armhfp-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-32-armhfp-rpmfusion_free.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-nonfree]
 name=RPM Fusion for Fedora 32 - Nonfree
 #baseurl=https://download1.rpmfusion.org/nonfree/fedora/releases/32/Everything/armhfp/os/

--- a/etc/mock/fedora-32-i386-kwizart.cfg
+++ b/etc/mock/fedora-32-i386-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-32-i386-rpmfusion_nonfree.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [kwizart]
 name=kwizart for Fedora 32 - i386 - Base
 baseurl=http://rpms.kwizart.net/fedora/32/i386/

--- a/etc/mock/fedora-32-i386-rpmfusion_free.cfg
+++ b/etc/mock/fedora-32-i386-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-32-i386.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free]
 name=RPM Fusion for Fedora 32 - Free
 #baseurl=https://download1.rpmfusion.org/free/fedora/releases/32/Everything/i386/os/

--- a/etc/mock/fedora-32-i386-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-32-i386-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-32-i386-rpmfusion_free.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-nonfree]
 name=RPM Fusion for Fedora 32 - Nonfree
 #baseurl=https://download1.rpmfusion.org/nonfree/fedora/releases/32/Everything/i386/os/

--- a/etc/mock/fedora-32-ppc64le-kwizart.cfg
+++ b/etc/mock/fedora-32-ppc64le-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-32-ppc64le-rpmfusion_nonfree.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [kwizart]
 name=kwizart for Fedora 32 - ppc64le - Base
 baseurl=http://rpms.kwizart.net/fedora/32/ppc64le/

--- a/etc/mock/fedora-32-ppc64le-rpmfusion_free.cfg
+++ b/etc/mock/fedora-32-ppc64le-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-32-ppc64le.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free]
 name=RPM Fusion for Fedora 32 - Free
 #baseurl=https://download1.rpmfusion.org/free/fedora/releases/32/Everything/ppc64le/os/

--- a/etc/mock/fedora-32-ppc64le-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-32-ppc64le-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-32-ppc64le-rpmfusion_free.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-nonfree]
 name=RPM Fusion for Fedora 32 - Nonfree
 #baseurl=https://download1.rpmfusion.org/nonfree/fedora/releases/32/Everything/ppc64le/os/

--- a/etc/mock/fedora-32-x86_64-kwizart.cfg
+++ b/etc/mock/fedora-32-x86_64-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-32-x86_64-rpmfusion_nonfree.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [kwizart]
 name=kwizart for Fedora 32 - x86_64 - Base
 baseurl=http://rpms.kwizart.net/fedora/32/x86_64/

--- a/etc/mock/fedora-32-x86_64-rpmfusion_free.cfg
+++ b/etc/mock/fedora-32-x86_64-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-32-x86_64.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free]
 name=RPM Fusion for Fedora 32 - Free
 #baseurl=https://download1.rpmfusion.org/free/fedora/releases/32/Everything/x86_64/os/

--- a/etc/mock/fedora-32-x86_64-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-32-x86_64-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-32-x86_64-rpmfusion_free.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-nonfree]
 name=RPM Fusion for Fedora 32 - Nonfree
 #baseurl=https://download1.rpmfusion.org/nonfree/fedora/releases/32/Everything/x86_64/os/

--- a/etc/mock/fedora-rawhide-aarch64-kwizart.cfg
+++ b/etc/mock/fedora-rawhide-aarch64-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-rawhide-aarch64-rpmfusion_nonfree.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [kwizart]
 name=kwizart for Fedora rawhide - aarch64 - Base
 baseurl=http://rpms.kwizart.net/fedora/rawhide/aarch64/

--- a/etc/mock/fedora-rawhide-aarch64-rpmfusion_free.cfg
+++ b/etc/mock/fedora-rawhide-aarch64-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-rawhide-aarch64.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free-rawhide]
 name=RPM Fusion for Fedora Rawhide - Free
 #baseurl=https://download1.rpmfusion.org/free/fedora/development/rawhide/Everything/aarch64/os/

--- a/etc/mock/fedora-rawhide-aarch64-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-rawhide-aarch64-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-rawhide-aarch64-rpmfusion_free.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-nonfree-rawhide]
 name=RPM Fusion for Fedora Rawhide - Nonfree
 #baseurl=https://download1.rpmfusion.org/nonfree/fedora/development/rawhide/Everything/aarch64/os/

--- a/etc/mock/fedora-rawhide-armhfp-kwizart.cfg
+++ b/etc/mock/fedora-rawhide-armhfp-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-rawhide-armhfp-rpmfusion_nonfree.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [kwizart]
 name=kwizart for Fedora rawhide - armhfp - Base
 baseurl=http://rpms.kwizart.net/fedora/rawhide/armhfp/

--- a/etc/mock/fedora-rawhide-armhfp-rpmfusion_free.cfg
+++ b/etc/mock/fedora-rawhide-armhfp-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-rawhide-armhfp.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free-rawhide]
 name=RPM Fusion for Fedora Rawhide - Free
 #baseurl=https://download1.rpmfusion.org/free/fedora/development/rawhide/Everything/armhfp/os/

--- a/etc/mock/fedora-rawhide-armhfp-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-rawhide-armhfp-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-rawhide-armhfp-rpmfusion_free.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-nonfree-rawhide]
 name=RPM Fusion for Fedora Rawhide - Nonfree
 #baseurl=https://download1.rpmfusion.org/nonfree/fedora/development/rawhide/Everything/armhfp/os/

--- a/etc/mock/fedora-rawhide-i386-kwizart.cfg
+++ b/etc/mock/fedora-rawhide-i386-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-rawhide-i386-rpmfusion_nonfree.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [kwizart]
 name=kwizart for Fedora rawhide - i386 - Base
 baseurl=http://rpms.kwizart.net/fedora/rawhide/i386/

--- a/etc/mock/fedora-rawhide-i386-rpmfusion_free.cfg
+++ b/etc/mock/fedora-rawhide-i386-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-rawhide-i386.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free-rawhide]
 name=RPM Fusion for Fedora Rawhide - Free
 #baseurl=https://download1.rpmfusion.org/free/fedora/development/rawhide/Everything/i386/os/

--- a/etc/mock/fedora-rawhide-i386-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-rawhide-i386-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-rawhide-i386-rpmfusion_free.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-nonfree-rawhide]
 name=RPM Fusion for Fedora Rawhide - Nonfree
 #baseurl=https://download1.rpmfusion.org/nonfree/fedora/development/rawhide/Everything/i386/os/

--- a/etc/mock/fedora-rawhide-ppc64le-kwizart.cfg
+++ b/etc/mock/fedora-rawhide-ppc64le-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-rawhide-ppc64le-rpmfusion_nonfree.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [kwizart]
 name=kwizart for Fedora rawhide - ppc64le - Base
 baseurl=http://rpms.kwizart.net/fedora/rawhide/ppc64le/

--- a/etc/mock/fedora-rawhide-ppc64le-rpmfusion_free.cfg
+++ b/etc/mock/fedora-rawhide-ppc64le-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-rawhide-ppc64le.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free-rawhide]
 name=RPM Fusion for Fedora Rawhide - Free
 #baseurl=https://download1.rpmfusion.org/free/fedora/development/rawhide/Everything/ppc64le/os/

--- a/etc/mock/fedora-rawhide-ppc64le-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-rawhide-ppc64le-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-rawhide-ppc64le-rpmfusion_free.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-nonfree-rawhide]
 name=RPM Fusion for Fedora Rawhide - Nonfree
 #baseurl=https://download1.rpmfusion.org/nonfree/fedora/development/rawhide/Everything/ppc64le/os/

--- a/etc/mock/fedora-rawhide-x86_64-kwizart.cfg
+++ b/etc/mock/fedora-rawhide-x86_64-kwizart.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-rawhide-x86_64-rpmfusion_nonfree.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [kwizart]
 name=kwizart for Fedora rawhide - x86_64 - Base
 baseurl=http://rpms.kwizart.net/fedora/rawhide/x86_64/

--- a/etc/mock/fedora-rawhide-x86_64-rpmfusion_free.cfg
+++ b/etc/mock/fedora-rawhide-x86_64-rpmfusion_free.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-rawhide-x86_64.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-free-rawhide]
 name=RPM Fusion for Fedora Rawhide - Free
 #baseurl=https://download1.rpmfusion.org/free/fedora/development/rawhide/Everything/x86_64/os/

--- a/etc/mock/fedora-rawhide-x86_64-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-rawhide-x86_64-rpmfusion_nonfree.cfg
@@ -1,6 +1,6 @@
 include('/etc/mock/fedora-rawhide-x86_64-rpmfusion_free.cfg')
 
-config_opts['yum.conf'] += """
+config_opts['dnf.conf'] += """
 [rpmfusion-nonfree-rawhide]
 name=RPM Fusion for Fedora Rawhide - Nonfree
 #baseurl=https://download1.rpmfusion.org/nonfree/fedora/development/rawhide/Everything/x86_64/os/


### PR DESCRIPTION
Upstream mock uses config_opts['dnf.conf'] for these targets¹.  Do the
same to avoid "KeyError: 'yum.conf'" when running mock for Fedora and
EPEL-8 chroots.

¹ cb25d3ba (mock, config: solve yum.conf vs. dnf.conf inconsistency,
  2020-02-07)

This was reported on the Fedora users list today (https://lists.fedoraproject.org/archives/list/users@lists.fedoraproject.org/thread/NT5YXELARAWXGQMQZTCL6Y63R3TXR66T/).  I just did a quick test with `mock -r fedora-30-x86_64-rpmfusion_free --shell` to check that `s/yum.conf/dnf.conf/` did the trick.