### PR TITLE
Restore cleanup functionality, made optional and more careful

### DIFF
--- a/etc/mock/fedora+rpmfusion_free-35-aarch64.cfg
+++ b/etc/mock/fedora+rpmfusion_free-35-aarch64.cfg
@@ -1,2 +1,0 @@
-include('fedora-35-aarch64.cfg')
-include('templates/rpmfusion_free-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_free-35-armhfp.cfg
+++ b/etc/mock/fedora+rpmfusion_free-35-armhfp.cfg
@@ -1,2 +1,0 @@
-include('fedora-35-armhfp.cfg')
-include('templates/rpmfusion_free-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_free-35-i386.cfg
+++ b/etc/mock/fedora+rpmfusion_free-35-i386.cfg
@@ -1,2 +1,0 @@
-include('fedora-35-i386.cfg')
-include('templates/rpmfusion_free-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_free-35-ppc64le.cfg
+++ b/etc/mock/fedora+rpmfusion_free-35-ppc64le.cfg
@@ -1,2 +1,0 @@
-include('fedora-35-ppc64le.cfg')
-include('templates/rpmfusion_free-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_free-35-x86_64.cfg
+++ b/etc/mock/fedora+rpmfusion_free-35-x86_64.cfg
@@ -1,2 +1,0 @@
-include('fedora-35-x86_64.cfg')
-include('templates/rpmfusion_free-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_free-36-aarch64.cfg
+++ b/etc/mock/fedora+rpmfusion_free-36-aarch64.cfg
@@ -1,2 +1,0 @@
-include('fedora-36-aarch64.cfg')
-include('templates/rpmfusion_free-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_free-36-armhfp.cfg
+++ b/etc/mock/fedora+rpmfusion_free-36-armhfp.cfg
@@ -1,2 +1,0 @@
-include('fedora-36-armhfp.cfg')
-include('templates/rpmfusion_free-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_free-36-i386.cfg
+++ b/etc/mock/fedora+rpmfusion_free-36-i386.cfg
@@ -1,2 +1,0 @@
-include('fedora-36-i386.cfg')
-include('templates/rpmfusion_free-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_free-36-ppc64le.cfg
+++ b/etc/mock/fedora+rpmfusion_free-36-ppc64le.cfg
@@ -1,2 +1,0 @@
-include('fedora-36-ppc64le.cfg')
-include('templates/rpmfusion_free-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_free-36-x86_64.cfg
+++ b/etc/mock/fedora+rpmfusion_free-36-x86_64.cfg
@@ -1,2 +1,0 @@
-include('fedora-36-x86_64.cfg')
-include('templates/rpmfusion_free-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_free-37-aarch64.cfg
+++ b/etc/mock/fedora+rpmfusion_free-37-aarch64.cfg
@@ -1,2 +1,0 @@
-include('fedora-37-aarch64.cfg')
-include('templates/rpmfusion_free-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_free-37-i386.cfg
+++ b/etc/mock/fedora+rpmfusion_free-37-i386.cfg
@@ -1,2 +1,0 @@
-include('fedora-37-i386.cfg')
-include('templates/rpmfusion_free-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_free-37-ppc64le.cfg
+++ b/etc/mock/fedora+rpmfusion_free-37-ppc64le.cfg
@@ -1,2 +1,0 @@
-include('fedora-37-ppc64le.cfg')
-include('templates/rpmfusion_free-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_free-37-x86_64.cfg
+++ b/etc/mock/fedora+rpmfusion_free-37-x86_64.cfg
@@ -1,2 +1,0 @@
-include('fedora-37-x86_64.cfg')
-include('templates/rpmfusion_free-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_nonfree-35-aarch64.cfg
+++ b/etc/mock/fedora+rpmfusion_nonfree-35-aarch64.cfg
@@ -1,2 +1,0 @@
-include('fedora+rpmfusion_free-35-aarch64.cfg')
-include('templates/rpmfusion_nonfree-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_nonfree-35-armhfp.cfg
+++ b/etc/mock/fedora+rpmfusion_nonfree-35-armhfp.cfg
@@ -1,2 +1,0 @@
-include('fedora+rpmfusion_free-35-armhfp.cfg')
-include('templates/rpmfusion_nonfree-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_nonfree-35-i386.cfg
+++ b/etc/mock/fedora+rpmfusion_nonfree-35-i386.cfg
@@ -1,2 +1,0 @@
-include('fedora+rpmfusion_free-35-i386.cfg')
-include('templates/rpmfusion_nonfree-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_nonfree-35-ppc64le.cfg
+++ b/etc/mock/fedora+rpmfusion_nonfree-35-ppc64le.cfg
@@ -1,2 +1,0 @@
-include('fedora+rpmfusion_free-35-ppc64le.cfg')
-include('templates/rpmfusion_nonfree-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_nonfree-35-x86_64.cfg
+++ b/etc/mock/fedora+rpmfusion_nonfree-35-x86_64.cfg
@@ -1,2 +1,0 @@
-include('fedora+rpmfusion_free-35-x86_64.cfg')
-include('templates/rpmfusion_nonfree-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_nonfree-36-aarch64.cfg
+++ b/etc/mock/fedora+rpmfusion_nonfree-36-aarch64.cfg
@@ -1,2 +1,0 @@
-include('fedora+rpmfusion_free-36-aarch64.cfg')
-include('templates/rpmfusion_nonfree-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_nonfree-36-armhfp.cfg
+++ b/etc/mock/fedora+rpmfusion_nonfree-36-armhfp.cfg
@@ -1,2 +1,0 @@
-include('fedora+rpmfusion_free-36-armhfp.cfg')
-include('templates/rpmfusion_nonfree-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_nonfree-36-i386.cfg
+++ b/etc/mock/fedora+rpmfusion_nonfree-36-i386.cfg
@@ -1,2 +1,0 @@
-include('fedora+rpmfusion_free-36-i386.cfg')
-include('templates/rpmfusion_nonfree-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_nonfree-36-ppc64le.cfg
+++ b/etc/mock/fedora+rpmfusion_nonfree-36-ppc64le.cfg
@@ -1,2 +1,0 @@
-include('fedora+rpmfusion_free-36-ppc64le.cfg')
-include('templates/rpmfusion_nonfree-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_nonfree-36-x86_64.cfg
+++ b/etc/mock/fedora+rpmfusion_nonfree-36-x86_64.cfg
@@ -1,2 +1,0 @@
-include('fedora+rpmfusion_free-36-x86_64.cfg')
-include('templates/rpmfusion_nonfree-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_nonfree-37-aarch64.cfg
+++ b/etc/mock/fedora+rpmfusion_nonfree-37-aarch64.cfg
@@ -1,2 +1,0 @@
-include('fedora+rpmfusion_free-37-aarch64.cfg')
-include('templates/rpmfusion_nonfree-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_nonfree-37-i386.cfg
+++ b/etc/mock/fedora+rpmfusion_nonfree-37-i386.cfg
@@ -1,2 +1,0 @@
-include('fedora+rpmfusion_free-37-i386.cfg')
-include('templates/rpmfusion_nonfree-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_nonfree-37-ppc64le.cfg
+++ b/etc/mock/fedora+rpmfusion_nonfree-37-ppc64le.cfg
@@ -1,2 +1,0 @@
-include('fedora+rpmfusion_free-37-ppc64le.cfg')
-include('templates/rpmfusion_nonfree-stable.tpl')

--- a/etc/mock/fedora+rpmfusion_nonfree-37-x86_64.cfg
+++ b/etc/mock/fedora+rpmfusion_nonfree-37-x86_64.cfg
@@ -1,2 +1,0 @@
-include('fedora+rpmfusion_free-37-x86_64.cfg')
-include('templates/rpmfusion_nonfree-stable.tpl')

--- a/etc/mock/fedora-35-aarch64-rpmfusion_free.cfg
+++ b/etc/mock/fedora-35-aarch64-rpmfusion_free.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_free-35-aarch64.cfg

--- a/etc/mock/fedora-35-aarch64-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-35-aarch64-rpmfusion_nonfree.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_nonfree-35-aarch64.cfg

--- a/etc/mock/fedora-35-armhfp-rpmfusion_free.cfg
+++ b/etc/mock/fedora-35-armhfp-rpmfusion_free.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_free-35-armhfp.cfg

--- a/etc/mock/fedora-35-armhfp-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-35-armhfp-rpmfusion_nonfree.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_nonfree-35-armhfp.cfg

--- a/etc/mock/fedora-35-i386-rpmfusion_free.cfg
+++ b/etc/mock/fedora-35-i386-rpmfusion_free.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_free-35-i386.cfg

--- a/etc/mock/fedora-35-i386-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-35-i386-rpmfusion_nonfree.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_nonfree-35-i386.cfg

--- a/etc/mock/fedora-35-ppc64le-rpmfusion_free.cfg
+++ b/etc/mock/fedora-35-ppc64le-rpmfusion_free.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_free-35-ppc64le.cfg

--- a/etc/mock/fedora-35-ppc64le-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-35-ppc64le-rpmfusion_nonfree.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_nonfree-35-ppc64le.cfg

--- a/etc/mock/fedora-35-x86_64-rpmfusion_free.cfg
+++ b/etc/mock/fedora-35-x86_64-rpmfusion_free.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_free-35-x86_64.cfg

--- a/etc/mock/fedora-35-x86_64-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-35-x86_64-rpmfusion_nonfree.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_nonfree-35-x86_64.cfg

--- a/etc/mock/fedora-36-aarch64-rpmfusion_free.cfg
+++ b/etc/mock/fedora-36-aarch64-rpmfusion_free.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_free-36-aarch64.cfg

--- a/etc/mock/fedora-36-aarch64-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-36-aarch64-rpmfusion_nonfree.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_nonfree-36-aarch64.cfg

--- a/etc/mock/fedora-36-armhfp-rpmfusion_free.cfg
+++ b/etc/mock/fedora-36-armhfp-rpmfusion_free.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_free-36-armhfp.cfg

--- a/etc/mock/fedora-36-armhfp-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-36-armhfp-rpmfusion_nonfree.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_nonfree-36-armhfp.cfg

--- a/etc/mock/fedora-36-i386-rpmfusion_free.cfg
+++ b/etc/mock/fedora-36-i386-rpmfusion_free.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_free-36-i386.cfg

--- a/etc/mock/fedora-36-i386-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-36-i386-rpmfusion_nonfree.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_nonfree-36-i386.cfg

--- a/etc/mock/fedora-36-ppc64le-rpmfusion_free.cfg
+++ b/etc/mock/fedora-36-ppc64le-rpmfusion_free.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_free-36-ppc64le.cfg

--- a/etc/mock/fedora-36-ppc64le-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-36-ppc64le-rpmfusion_nonfree.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_nonfree-36-ppc64le.cfg

--- a/etc/mock/fedora-36-x86_64-rpmfusion_free.cfg
+++ b/etc/mock/fedora-36-x86_64-rpmfusion_free.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_free-36-x86_64.cfg

--- a/etc/mock/fedora-36-x86_64-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-36-x86_64-rpmfusion_nonfree.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_nonfree-36-x86_64.cfg

--- a/etc/mock/fedora-37-aarch64-rpmfusion_free.cfg
+++ b/etc/mock/fedora-37-aarch64-rpmfusion_free.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_free-37-aarch64.cfg

--- a/etc/mock/fedora-37-aarch64-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-37-aarch64-rpmfusion_nonfree.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_nonfree-37-aarch64.cfg

--- a/etc/mock/fedora-37-i386-rpmfusion_free.cfg
+++ b/etc/mock/fedora-37-i386-rpmfusion_free.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_free-37-i386.cfg

--- a/etc/mock/fedora-37-i386-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-37-i386-rpmfusion_nonfree.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_nonfree-37-i386.cfg

--- a/etc/mock/fedora-37-ppc64le-rpmfusion_free.cfg
+++ b/etc/mock/fedora-37-ppc64le-rpmfusion_free.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_free-37-ppc64le.cfg

--- a/etc/mock/fedora-37-ppc64le-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-37-ppc64le-rpmfusion_nonfree.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_nonfree-37-ppc64le.cfg

--- a/etc/mock/fedora-37-x86_64-rpmfusion_free.cfg
+++ b/etc/mock/fedora-37-x86_64-rpmfusion_free.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_free-37-x86_64.cfg

--- a/etc/mock/fedora-37-x86_64-rpmfusion_nonfree.cfg
+++ b/etc/mock/fedora-37-x86_64-rpmfusion_nonfree.cfg
@@ -1,1 +1,0 @@
-fedora+rpmfusion_nonfree-37-x86_64.cfg

--- a/round.sh
+++ b/round.sh
@@ -10,6 +10,10 @@ etc_mock=../mock/mock-core-configs/etc/mock
 # with mock rpmfusion configuration
 #etc_mock=/etc/mock
 
+# uncomment the next line to delete old configuration for versions removed
+# from $etc_mock (requires etc_mock)
+#cleanup=1
+
 
 for arch in $ARCHES ; do
   for repo in $REPOS ; do
@@ -35,21 +39,27 @@ for arch in $ARCHES ; do
     fver=rawhide
   fi
 
+  cfg_upstream="${etc_mock}/fedora-${fver}-${arch}.cfg"
+  cfg_name_new="fedora+${repo}-${fver}-${arch}.cfg"
+  cfg_name_old="fedora-${fver}-${arch}-${repo}.cfg"
+
   # if $etc_mock directory exist, check .cfg files
-  if [ -d "${etc_mock}" ] && [ ! -f "${etc_mock}/fedora-${fver}-${arch}.cfg" ] ; then
-    echo "doesnt exist ${etc_mock}/fedora-${fver}-${arch}.cfg"
+  if [ -d "$(dirname "${cfg_upstream}")" ] && [ ! -f "${cfg_upstream}" ] ; then
+    echo "does not exist ${cfg_upstream}"
+    if [ x"$cleanup" != x"" ] && [ -f "etc/mock/$cfg_name_new" ]; then
+      rm -f "etc/mock/$cfg_name_new"
+      rm -f "etc/mock/$cfg_name_old"
+    fi
     continue
   fi
 
-  cfg_name_new="fedora+${repo}-${fver}-${arch}.cfg"
-  cfg_name_old="fedora-${fver}-${arch}-${repo}.cfg"
   if [ "$repo" = rpmfusion_free ] ; then
-    echo "include('fedora-${fver_alt}-${arch}.cfg')" > $cfg_name_new
-    echo "include('templates/rpmfusion_free-${flavour}.tpl')" >> $cfg_name_new
+    echo "include('fedora-${fver_alt}-${arch}.cfg')" > "$cfg_name_new"
+    echo "include('templates/rpmfusion_free-${flavour}.tpl')" >> "$cfg_name_new"
   fi
   if [ "$repo" = rpmfusion_nonfree ] ; then
-    echo "include('fedora+rpmfusion_free-${fver}-${arch}.cfg')" > $cfg_name_new
-    echo "include('templates/rpmfusion_nonfree-${flavour}.tpl')" >> $cfg_name_new
+    echo "include('fedora+rpmfusion_free-${fver}-${arch}.cfg')" > "$cfg_name_new"
+    echo "include('templates/rpmfusion_nonfree-${flavour}.tpl')" >> "$cfg_name_new"
   fi
 #  sed -i -e "s|\$basearch|${arch}|g" fedora+${fver}-${arch}-${repo}.cfg
 #  sed -i -e "s|\$releasever|${fver}|g" fedora-${fver}-${arch}-${repo}.cfg
@@ -61,9 +71,9 @@ for arch in $ARCHES ; do
     #    sed -i -e "s|free/fedora/|free/fedora-secondary/|g" fedora-${fver}-${arch}-${repo}.cfg
     #fi
   #fi
-  ln -sr $cfg_name_new $cfg_name_old
-  mv $cfg_name_old etc/mock/
-  mv $cfg_name_new etc/mock/
+  ln -sr "$cfg_name_new" "$cfg_name_old"
+  mv "$cfg_name_old" etc/mock/
+  mv "$cfg_name_new" etc/mock/
   #git add etc/mock/fedora-${fver}-${arch}-${repo}.cfg
   #sed -i -e "s|mirrorlist=http://mirrors.rpmfusion.org|#mirrorlist=http://mirrors.rpmfusion.org|g" fedora-${fver}-${arch2}-${repo}.cfg
   #sed -i -e "s|kojipkgs.fedoraproject.org|sparc.koji.fedoraproject.org|g" fedora-${fver}-${arch2}-${repo}.cfg


### PR DESCRIPTION
A variable setting `cleanup=1` will trigger deletion of the output
files when the `$etc_mock` check fails.

(`cleanup=1` is commented out, but the scripts can be run with
e.g. `cleanup=1 ./round.sh` to enable it for the run.)

In `el-round.sh`, the existence check will use `$etc_mock` for
versions < 8, but will check `etc/mock/` for later versions (since
we're now keeping our own links). The check will also explicitly
test for symbolic links (`-L`) rather than files (`-f`), because
the links in `etc/mock/` are expected to be broken.

- Restore shellcheck fixes from #22
- Replace "doesnt exist" with "does not exist"

The second commit contains all of the deletions triggered by running `cleanup=1 ./round.sh`, removing all of the invalid Fedora 35/36/37-based mock configurations, since the `fedora-3[567]-${arch}.cfg` files are no longer distributed in upstream `mock-core-configs`.